### PR TITLE
Fix log newline handling

### DIFF
--- a/public/server.js
+++ b/public/server.js
@@ -41,7 +41,7 @@ app.post("/log",(req,res)=>{
     try { body = JSON.parse(body); } catch { body = {}; }
   }
 
-  const instruction = body.instruction || "なし";
+  const instruction = (body.instruction || "なし").replace(/\r?\n/g, " ");
   const duration    = body.duration    || 0;              // ★追加（ms）
   const userIP      = req.headers["x-forwarded-for"] || req.socket.remoteAddress;
   const page        = body.page || req.get("referer") || "-";

--- a/server.js
+++ b/server.js
@@ -41,7 +41,7 @@ app.post("/log",(req,res)=>{
     try { body = JSON.parse(body); } catch { body = {}; }
   }
 
-  const instruction = body.instruction || "なし";
+  const instruction = (body.instruction || "なし").replace(/\r?\n/g, " ");
   const duration    = body.duration    || 0;              // ★追加（ms）
   const userIP      = req.headers["x-forwarded-for"] || req.socket.remoteAddress;
   const page        = body.page || req.get("referer") || "-";


### PR DESCRIPTION
## Summary
- sanitize multiline instructions in `/log` endpoint
- same fix in standalone `public/server.js`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `curl -X POST http://localhost:6200/log -H 'Content-Type: application/json' -d '{"instruction":"Line1\nLine2"}'`

------
https://chatgpt.com/codex/tasks/task_e_68847f8238e08330be351a9a252b8efc