### PR TITLE
Add new default GPT model

### DIFF
--- a/manage.js
+++ b/manage.js
@@ -191,7 +191,7 @@ export default function addManageRoutes(app) {
           contact :(req.body.contact ||"").trim(),
           prompt  :(req.body.prompt  ||"").trim(),
           voice   :(req.body.voice   ||"sage").trim(),
-          model   :(req.body.model   ||"gpt-4o-realtime-preview-2024-12-17").trim(),
+          model   :(req.body.model   ||"gpt-4o-realtime-preview-2025-06-03").trim(),
           logo    : req.files?.logo
                       ? req.files.logo[0].path.replace("public","")
                       : req.body.logoPrev || "",

--- a/public/manage.html
+++ b/public/manage.html
@@ -102,7 +102,9 @@
 
   <p><label>デフォルトモデル</label>
      <select name="model">
-       <option value="gpt-4o-realtime-preview-2024-12-17" selected>
+       <option value="gpt-4o-realtime-preview-2025-06-03" selected>
+         gpt-4o-realtime-preview-2025-06-03</option>
+       <option value="gpt-4o-realtime-preview-2024-12-17">
          gpt-4o-realtime-preview-2024-12-17</option>
        <option value="gpt-4o-mini-realtime-preview-2024-12-17">
          gpt-4o-mini-realtime-preview-2024-12-17</option>

--- a/public/server.js
+++ b/public/server.js
@@ -18,7 +18,7 @@ app.use(express.json());
 
 /* ---------- 1. Ephemeral キー取得 ---------- */
 app.get("/session", async (req, res) => {
-  const model = req.query.model || "gpt-4o-realtime-preview-2024-12-17";
+  const model = req.query.model || "gpt-4o-realtime-preview-2025-06-03";
   try {
     const r = await fetch("https://api.openai.com/v1/realtime/sessions",{
       method :"POST",

--- a/server.js
+++ b/server.js
@@ -18,7 +18,7 @@ app.use(express.json());
 
 /* ---------- 1. Ephemeral キー取得 ---------- */
 app.get("/session", async (req, res) => {
-  const model = req.query.model || "gpt-4o-realtime-preview-2024-12-17";
+  const model = req.query.model || "gpt-4o-realtime-preview-2025-06-03";
   try {
     const r = await fetch("https://api.openai.com/v1/realtime/sessions",{
       method :"POST",


### PR DESCRIPTION
## Summary
- add `gpt-4o-realtime-preview-2025-06-03` as the default model in manage UI
- update backend defaults to use this model

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68848ff017788330bb41d7f792aceefa