### PR TITLE
Add configurable chat heading label

### DIFF
--- a/manage.js
+++ b/manage.js
@@ -44,9 +44,14 @@ export default function addManageRoutes(app) {
             .replace('<input name="slug">', `<input name="slug" value="${cfg.slug}">`)
             .replace('<input name="titleTag">', `<input name="titleTag" value="${cfg.titleTag}">`)
             .replace('<input name="heading">', `<input name="heading" value="${cfg.heading}">`)
+            .replace('<input name="chatLabel">', `<input name="chatLabel" value="${cfg.chatLabel ?? ""}">`)
+            .replace(
+              '<input type="hidden" name="chatLabelPrev" id="chatLabelPrev">',
+              `<input type="hidden" name="chatLabelPrev" id="chatLabelPrev" value="${cfg.chatLabel ?? ""}">`
+            )
             .replace(/name="contact"[^>]+>/, `name="contact" value="${cfg.contact}">`)
             // ▼ 自動ジャンプ秒数を反映
-            .replace('<input name="autoJumpSec" type="number" min="1" value="180">', 
+            .replace('<input name="autoJumpSec" type="number" min="1" value="180">',
                      `<input name="autoJumpSec" type="number" min="1" value="${cfg.autoJumpSec || 180}">`)
             .replace(/<textarea name="prompt"[\s\S]*?<\/textarea>/,
                      `<textarea name="prompt" rows="4" cols="40">${cfg.prompt}</textarea>`)
@@ -190,6 +195,7 @@ export default function addManageRoutes(app) {
           heading :(req.body.heading ||"").trim(),
           contact :(req.body.contact ||"").trim(),
           prompt  :(req.body.prompt  ||"").trim(),
+          chatLabel:(req.body.chatLabel ?? req.body.chatLabelPrev ?? "").trim(),
           voice   :(req.body.voice   ||"sage").trim(),
           model   :(req.body.model   ||"gpt-4o-realtime-preview-2025-06-03").trim(),
           logo    : req.files?.logo
@@ -255,10 +261,13 @@ export default function addManageRoutes(app) {
       const cfg = JSON.parse(
         await fs.readFile(`configs/${req.params.slug}.json`, "utf8")
       );
+      const chatLabel = (cfg.chatLabel ?? "").trim();
+      const headingText = chatLabel || cfg.heading || "3分間 AI-Realtime 音声チャット";
       let html = await fs.readFile("public/index.html", "utf8");
       html = html
         .replace(/<title>.*?<\/title>/, `<title>${cfg.titleTag}</title>`)
-        .replace(/<h2>.*?<\/h2>/, `<h2>${cfg.heading}</h2>`)
+        .replace(/<h2[^>]*data-role="chat-heading"[^>]*>[\s\S]*?<\/h2>/,
+                 `<h2 data-role="chat-heading">${headingText}</h2>`)
         .replace(/src="[^"]*logo[^"]*"/, `src="${cfg.logo}"`)
         // ② オペレーター画像 ― class="operator-img" の <img> タグを丸ごと置換
         .replace(/<img[^>]+class="operator-img"[^>]*>/,

--- a/public/index.html
+++ b/public/index.html
@@ -28,7 +28,8 @@ audio{width:100%;margin-top:20px}
 
 <header>
   <img src="https://recovision.sakura.ne.jp/20250331-gpt-tts/logo.jpg" class="logo" alt="ロゴ">
-  <h2>3分間 AI-Realtime 音声チャット</h2>
+  <!-- Managed chat heading placeholder -->
+  <h2 data-role="chat-heading">3分間 AI-Realtime 音声チャット</h2>
   <a href="https://www.bordertech.co.jp/contact/" class="contact">
     <img src="https://recovision.sakura.ne.jp/20250331-gpt-tts/hikari.jpg" alt="Contact">Contact
   </a>

--- a/public/manage.html
+++ b/public/manage.html
@@ -90,6 +90,10 @@
   <p><label>見出し（キャッチコピー）</label><input name="heading">
      <span class="note">※ページ上部の説明です。</span></p>
 
+  <p><label>チャットヘッダー</label><input name="chatLabel">
+     <input type="hidden" name="chatLabelPrev" id="chatLabelPrev">
+     <span class="note">※チャット枠の見出し。未設定の場合は上記の見出しを使用します。</span></p>
+
   <p><label>問い合わせ先リンク</label>
      <input name="contact" value="https://www.bordertech.co.jp/contact/">
      <span class="note">※問い合わせ先のリンク先を記入。</span></p>


### PR DESCRIPTION
## Summary
- add a chat header input and helper hidden field to the manage form with explanatory copy
- persist the new chatLabel property when saving configs and inject it into rendered slug pages with fallbacks
- tag the public chat heading element so it can be swapped while preserving the default text

## Testing
- node -e "const fs=require('fs');for(const f of fs.readdirSync('configs')){if(!f.endsWith('.json')) continue;const cfg=JSON.parse(fs.readFileSync('configs/'+f,'utf8'));const chatLabel=(cfg.chatLabel??'').trim();const headingText=chatLabel||cfg.heading||'3分間 AI-Realtime 音声チャット';console.log(f,'->',headingText);}"

------
https://chatgpt.com/codex/tasks/task_e_68da012a174c8330a14624b383cd5f59